### PR TITLE
Add preservePosition option to DragMarker

### DIFF
--- a/lib/dragmarker.dart
+++ b/lib/dragmarker.dart
@@ -81,6 +81,14 @@ class _DragMarkerWidgetState extends State<DragMarkerWidget> {
   }
 
   @override
+  void didUpdateWidget(covariant DragMarkerWidget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!widget.marker.preservePosition && !isDragging) {
+      markerPoint = widget.marker.point;
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     DragMarker marker = widget.marker;
     updatePixelPos(markerPoint);
@@ -338,6 +346,7 @@ class DragMarker {
   final double nearEdgeRatio;
   final double nearEdgeSpeed;
   final bool rotateMarker;
+  final bool preservePosition;
   late Anchor anchor;
 
   DragMarker({
@@ -361,6 +370,7 @@ class DragMarker {
     this.nearEdgeRatio = 1.5,
     this.nearEdgeSpeed = 1.0,
     this.rotateMarker = true,
+    this.preservePosition = true,
     AnchorPos? anchorPos,
   }) {
     anchor = Anchor.forPos(anchorPos, width, height);


### PR DESCRIPTION
Would resolve #21. I realized that this option would be super easy to implement without losing any of the flexibility offered by allowing users to pass through a Key.

Let me know if you prefer a different name than `preservePosition`. Also not sure if the `&& !isDragging` is necessary.