### PR TITLE
add Marker.rotateOrigin 

### DIFF
--- a/lib/src/drag_marker.dart
+++ b/lib/src/drag_marker.dart
@@ -80,6 +80,9 @@ class DragMarker {
   /// The center of rotation (anchor) will be opposite this.
   final Alignment? alignment;
 
+  /// The offset for rotating the marker
+  final Offset? rotateOrigin;
+
   DragMarker({
     required this.point,
     this.key,
@@ -101,6 +104,7 @@ class DragMarker {
     this.scrollNearEdgeSpeed = 1.0,
     this.rotateMarker = true,
     this.alignment,
+    this.rotateOrigin,
   });
 
   /// This method checks if the marker is in the current map bounds

--- a/lib/src/drag_marker_widget.dart
+++ b/lib/src/drag_marker_widget.dart
@@ -90,6 +90,7 @@ class DragMarkerWidgetState extends State<DragMarkerWidget> {
                       angle: -widget.mapCamera.rotationRad,
                       alignment: (marker.alignment ?? widget.alignment) * -1,
                       child: displayMarker,
+                      origin: marker.rotateOrigin,
                     )
                   : displayMarker,
             )


### PR DESCRIPTION
This PR adds the Marker.rotateOrigin attribute to keep the marker on the correct position while rotating.

I'm using a push pin which needs to rotate around the tiny pin on the bottom of the icon. Without the rotate origin the Icon rotates around the wrong origin, thus the position of the marker is not correct.