### PR TITLE
fix: remove use of subtraction Point extension from flutter_map beta

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -24,7 +24,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_map: ^6.0.0
+  flutter_map: ^7.0.0-dev.1
   flutter_map_dragmarker:
     path: ../
   latlong2: ">=0.8.0 <0.10.0"

--- a/lib/src/drag_marker_widget.dart
+++ b/lib/src/drag_marker_widget.dart
@@ -114,7 +114,7 @@ class DragMarkerWidgetState extends State<DragMarkerWidget> {
     final right = marker.size.width - left;
     final bottom = marker.size.height - top;
 
-    final pos = pxPoint.subtract(map.pixelOrigin.toDoublePoint());
+    final pos = Point(pxPoint.x - map.pixelOrigin.toDoublePoint().x, pxPoint.y - map.pixelOrigin.toDoublePoint().y);
     pixelPosition = Point(pos.x - right, pos.y - bottom);
   }
 
@@ -231,8 +231,7 @@ class DragMarkerWidgetState extends State<DragMarkerWidget> {
 
     // convert the point to global coordinates
     final localPoint = Point<double>(offset.dx, offset.dy);
-    final localPointCenterDistance =
-        Point<double>((width / 2) - localPoint.x, (height / 2) - localPoint.y);
+    final localPointCenterDistance = Point<double>((width / 2) - localPoint.x, (height / 2) - localPoint.y);
     final mapCenter = mapState.project(mapState.center);
     final point = mapCenter - localPointCenterDistance;
     return mapState.unproject(point);
@@ -249,19 +248,15 @@ class DragMarkerWidgetState extends State<DragMarkerWidget> {
     final pixelPoint = mapState.project(markerPoint);
     // How much we'll move the map by to compensate
     var scrollMapX = 0.0;
-    if (pixelPoint.x + marker.size.width * marker.scrollNearEdgeRatio >=
-        pixelB.topRight.x) {
+    if (pixelPoint.x + marker.size.width * marker.scrollNearEdgeRatio >= pixelB.topRight.x) {
       scrollMapX = marker.scrollNearEdgeSpeed;
-    } else if (pixelPoint.x - marker.size.width * marker.scrollNearEdgeRatio <=
-        pixelB.bottomLeft.x) {
+    } else if (pixelPoint.x - marker.size.width * marker.scrollNearEdgeRatio <= pixelB.bottomLeft.x) {
       scrollMapX = -marker.scrollNearEdgeSpeed;
     }
     var scrollMapY = 0.0;
-    if (pixelPoint.y - marker.size.height * marker.scrollNearEdgeRatio <=
-        pixelB.topRight.y) {
+    if (pixelPoint.y - marker.size.height * marker.scrollNearEdgeRatio <= pixelB.topRight.y) {
       scrollMapY = -marker.scrollNearEdgeSpeed;
-    } else if (pixelPoint.y + marker.size.height * marker.scrollNearEdgeRatio >=
-        pixelB.bottomLeft.y) {
+    } else if (pixelPoint.y + marker.size.height * marker.scrollNearEdgeRatio >= pixelB.bottomLeft.y) {
       scrollMapY = marker.scrollNearEdgeSpeed;
     }
     return Offset(scrollMapX, scrollMapY);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,17 +1,22 @@
 name: flutter_map_dragmarker
 description: Dragmarker class for flutter_map
-version: 6.0.0
+version: 6.1.0
 repository: https://github.com/ibrierley/flutter_map_dragmarker
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: '>=3.0.0'
 
 dependencies:
   flutter:
     sdk: flutter
-  flutter_map: ^6.0.0
-  latlong2: ">=0.8.0 <0.10.0"
+  flutter_map: ^6.1.0
+  latlong2: ^0.9.0
+
+dependency_overrides:
+  flutter_map:
+    git:
+      url: https://github.com/fleaflet/flutter_map.git
+      # ref: main (custom branch/commit)
 
 dev_dependencies:
   flutter_lints: ">=1.0.4"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_map_dragmarker
 description: Dragmarker class for flutter_map
-version: 6.1.0
+version: 6.0.0
 repository: https://github.com/ibrierley/flutter_map_dragmarker
 
 environment:
@@ -11,12 +11,6 @@ dependencies:
     sdk: flutter
   flutter_map: ^6.1.0
   latlong2: ^0.9.0
-
-dependency_overrides:
-  flutter_map:
-    git:
-      url: https://github.com/fleaflet/flutter_map.git
-      # ref: main (custom branch/commit)
 
 dev_dependencies:
   flutter_lints: ">=1.0.4"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_map: ^6.1.0
+  flutter_map: ^7.0.0-dev.1
   latlong2: ^0.9.0
 
 dev_dependencies:


### PR DESCRIPTION
Prepares for beta flutter_map. Fixes an issue where instead of using a now removed extension of `Point` from `dart:math` in `flutter_map`, do subtraction calculation within `drag_marker_widget.dart`